### PR TITLE
Corrected getAdjCells() 

### DIFF
--- a/js/cell.js
+++ b/js/cell.js
@@ -10,16 +10,16 @@ class  Cell {
 
     getAdjCells() {
         var adj = [];
-        var lastRow = board.length - 1;
-        var lastCol = board[0].length - 1;
-        if (this.row > 0 && this.col > 0) adj.push(board[this.row - 1][this.col - 1]);
-        if (this.row > 0) adj.push(board[this.row - 1][this.col]);
-        if (this.row > 0 && this.col < lastCol) adj.push(board[this.row - 1][this.col + 1]);
-        if (this.col < lastCol) adj.push(board[this.row][this.col + 1]);
-        if (this.row < lastRow && this.col < lastCol) adj.push(board[this.row + 1][this.col + 1]);
-        if (this.row < lastRow) adj.push(board[this.row + 1][this.col]);
-        if (this.row < lastRow && this.col > 0) adj.push(board[this.row + 1][this.col - 1]);
-        if (this.col > 0) adj.push(board[this.row][this.col - 1]);       
+        var lastRow = this.board.length - 1;
+        var lastCol = this.board[0].length - 1;
+        if (this.row > 0 && this.col > 0) adj.push(this.board[this.row - 1][this.col - 1]);
+        if (this.row > 0) adj.push(this.board[this.row - 1][this.col]);
+        if (this.row > 0 && this.col < lastCol) adj.push(this.board[this.row - 1][this.col + 1]);
+        if (this.col < lastCol) adj.push(this.board[this.row][this.col + 1]);
+        if (this.row < lastRow && this.col < lastCol) adj.push(this.board[this.row + 1][this.col + 1]);
+        if (this.row < lastRow) adj.push(this.board[this.row + 1][this.col]);
+        if (this.row < lastRow && this.col > 0) adj.push(this.board[this.row + 1][this.col - 1]);
+        if (this.col > 0) adj.push(this.board[this.row][this.col - 1]);       
         return adj;
     }
 


### PR DESCRIPTION
**Issue:**
In the current version, the getAdjCells function reference the board using 'board'. However, by not specifying the scope using 'this.'—like it currently does for 'this.row' and 'this.col'—it produces incorrect and seemingly random results. By including the scope identifier, the function now produces the desired result. 

**Test:**
Below is a simple test that creates a 3x3 board and places 2 bombs in that board. It then runs the getAdjCells function on a cell in that board which should output 2. However, without including the 'this.' keyword, it produces inconsistent results even though it is ran on the same board and cell. Once the keyword is included, the function only output the correct result.
```Javascript
function testGetAdjBombs() {
  // Create a controlled 3x3 board with new Cell instances.
  let testBoard = [];
  for (let i = 0; i < 3; i++) {
    let row = [];
    for (let j = 0; j < 3; j++) {
      // Temporarily set the board to null; we'll assign it next.
      row.push(new Cell(i, j, null));
    }
    testBoard.push(row);
  }
  
  // Assign the test board to each cell's board property.
  testBoard.forEach(row => {
    row.forEach(cell => cell.board = testBoard);
  });
  
  // Place bombs at known positions (e.g., (0,1) and (1,1)).
  testBoard[0][1].bomb = true;
  testBoard[1][1].bomb = true;
  
  // Recalculate adjacent bomb counts for all cells.
  testBoard.forEach(row => {
    row.forEach(cell => cell.calcAdjBombs());
  });
  
  // For cell at (1,0), the expected adjacent bomb count is 2.
  console.log('Cell (1,0) adjacent bombs:', testBoard[1][0].adjBombs);
}

testGetAdjBombs();
```